### PR TITLE
Update outputs.tf

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "jenkins_password_command" {
 }
 
 output "register_kubectl_command" {
-  value = "gcloud container clusters get-credentials ${google_container_cluster.demo.name}--region us-east1 --project ${google_project.demo.id}"
+  value = "gcloud container clusters get-credentials ${google_container_cluster.demo.name} --region us-east1 --project ${google_project.demo.project_id}"
 }
 
 output "mongodb_instance_connect_command" {


### PR DESCRIPTION
The register kubectl command did not work. Updated the outputs.tf command:
Added missing space before --region and replaced "${google_project.demo.id}" by "${google_project.demo.project_id}"